### PR TITLE
Add full-text examples for agent reports

### DIFF
--- a/isis.sql
+++ b/isis.sql
@@ -116,7 +116,5 @@ reentry capsule
 laser watch
 \.
 
-CREATE
-
 CREATE INDEX reports_attrs_idx ON reports USING gin (attrs);
 

--- a/isis.sql
+++ b/isis.sql
@@ -32,7 +32,7 @@ CREATE TABLE gear_names (
 CREATE TABLE reports (
     agent_uuid uuid,
     "time" timestamp with time zone,
-    attrs hstore default '{}'
+    attrs hstore default NULL
 );
 
 COPY agents (uuid, name, birthday, affiliation, tags) FROM stdin;
@@ -48,13 +48,6 @@ e151b10e-faf3-41bf-8b11-8ea06f82d6dd	Ray Gillette	1978-08-02	ISIS	{}
 6ab41fe3-0f58-40c1-8e42-5a74e4265a21	Sterling Archer	1976-04-11	ISIS	{double-agent,probation,arrears}
 5049ee7f-b016-4e0a-aed8-2b8566b7045a	Barry Dylan	1980-04-22	ODIN	{double-agent,probation,arrears}
 \.
-
-CREATE TABLE agent_statuses AS 
-  (SELECT
-    (SELECT uuid FROM agents ORDER BY random()+g*0 LIMIT 1) as agent_uuid,
-    (ARRAY['training','idle','assigned','captured','recovering'])[random() * 4 + 1] as state,
-    now() - '1 year ago'::interval * random() as time
-  FROM generate_series(1, 1000) as g);
 
 COPY countries (name) FROM stdin;
 Switzerland
@@ -100,7 +93,7 @@ sleeping gas
 silver platter
 \.
 
-CREATE TABLE agent_statuses AS 
+INSERT INTO agent_statuses(agent_uuid, state, time)
   (SELECT
     (SELECT uuid FROM agents ORDER BY random()+g*0 LIMIT 1) as agent_uuid,
     (ARRAY['training','idle','assigned','captured','recovering'])[random() * 4 + 1] as state,


### PR DESCRIPTION
Add TEXT and corresponding TSVECTOR columns to the reports table to
support full-text search of agent reports, along with a trigger to
automatically populate the TSVECTOR column, a GIN index on the TSVECTOR
column to provide performant search, and some sample data. More sample
reports needed!

Signed-off-by: Dan Scott dan@coffeecode.net
